### PR TITLE
Clean up excessive comments on the collaborator issues

### DIFF
--- a/collaborators.rb
+++ b/collaborators.rb
@@ -7,8 +7,9 @@ class Collaborator
     # Get Issue Commenters and Add as Collaborators
     successfully_added_users = []
     current_collaborators = get_current_collaborators(repo_name)
+    issueComments = client.issue_comments(repo_name, issue_num)
     begin
-      client.issue_comments(repo_name, issue_num).each do |comment|
+      issueComments.each do |comment|
         username = comment[:user][:login]
         puts "adding #{username}"
         next if current_collaborators[username] # skip adding if already a collaborator

--- a/collaborators.rb
+++ b/collaborators.rb
@@ -52,6 +52,12 @@ class Collaborator
         abort "ERR posting comment (#{e.inspect})"
       end
     end
+
+    if issueComments.size > 15
+      puts "There are over 15 (#{issueComments.size} to be exact) comments, cleaning up..."
+      removeExtraComments(repo_name, issueComments)
+    end
+
   end
 
   def self.access_token
@@ -67,4 +73,19 @@ class Collaborator
       [collaborator[:login], collaborator[:login]]
     }]
   end
+
+  def self.removeExtraComments( repo_name, comments )
+    totalComments = comments.size
+    puts "> Initial size: #{totalComments}"
+    comments.each do |comment|
+      puts "removing comment id #{comment[:id]}"
+      client.delete_comment(repo_name, comment[:id])
+      totalComments -= 1
+      puts "now there are #{totalComments} comments"
+      if totalComments < 15 then
+        break
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
This PR adds some code that should:
1. Go through the regular process of adding the person that triggered the request
1. Figure out how many comments there are in total
1. If there are >15 comments, make a call to `removeExtraComments()`
1. Step through all comments, starting at the oldest, until 14 comments remain.

👀 @brianamarie @crichid @hollenberry @beardofedu @stoe