### PR TITLE
Check before adding collaborator

### DIFF
--- a/basics.rb
+++ b/basics.rb
@@ -9,11 +9,12 @@ post '/payload' do
   push = JSON.parse(request.body.read)
   puts "I got some JSON: #{push.inspect}"
 
+  action = push["action"].to_s
   repo = push["repository"]["full_name"].to_s
   issue = push["issue"]["number"].to_i
   user = push["issue"]["user"]["login"].to_s
 
-  Collaborator.addByIssue repo_name: repo, issue_num: issue, user_login: user
+  Collaborator.addByIssue(repo_name: repo, issue_num: issue, user_login: user) if action == "opened"
 end
 
 get '/' do


### PR DESCRIPTION
@brianamarie @hectorsector, as discussed on Slack, add a check to only add collaborators for newly created issues.

This will also lower the calls to the GitHub API as it exits early for all other actions (e.g. `reopened`, `closed`, `push`, etc).